### PR TITLE
Rewrite authentication lesson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+.idea/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -601,7 +601,7 @@ the `/status` endpoint is being blocked since we aren't authenticated:
 It looks like it worked!
 
 Let's add our basic authentication back in the "Authorization" tab and ensure
-we can hit the status endpoint again.
+we can hit the status endpoint.
 
 ![postman-authenticated](https://curriculum-content.s3.amazonaws.com/spring-mod-2/authentication/postman-authenticated-status.png)
 

--- a/README.md
+++ b/README.md
@@ -465,7 +465,7 @@ Let's break down this code a little bit more:
     expired, and enabled. For our purposes, we'll be leaving these set to true
     so we won't have to worry about expired or locked credentials.
 
-A question we might still have is "Why does the password need to be encoded
+A question we might still have is "why does the password need to be encoded
 here?" Since Spring requires the password to be protected and secured, and we
 are using the `BCryptPasswordEncoder` in the `SecurityConfiguration` class, we
 must be consistent in how we are returning the password. Notice in our database,

--- a/README.md
+++ b/README.md
@@ -157,14 +157,6 @@ dependency:
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-oauth2-client</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-security</artifactId>
     </dependency>
     <dependency>

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Authentication
+# Code Along: Authentication
 
 ## Learning Goals
 

--- a/README.md
+++ b/README.md
@@ -2,424 +2,521 @@
 
 ## Learning Goals
 
-- Explain DispatcherServlet.
-- Set up authentication.
+- Briefly explain how authentication works with Spring Security.
+- Set up authentication using users we define.
+- Practice and test using Postman with authentication.
 
 ## Introduction
 
-Before we dive into the specifics of how to configure security for a Spring Boot
-application, we need to discuss servlets and how they are the underpinning of
-the web functionality that the Spring Framework provides.
+In the last lesson, we saw how we can use authentication to access our API
+when using Spring Security at its default. Remember, authentication is the
+process of validating that a user is who they claim to be.
 
-Afterwards, we will set up an authentication system for the project.
+But what if we want to authenticate our own users? How can we do that in Spring?
 
-## DispatcherServlet, servlet filters and servlet chains
-
-As you have learned, the Spring Framework is a Dependency Injection (DI) and
-Aspect Oriented Programming (AOP) framework, and has many components built
-around it that take advantage of its DI and AOP capabilities.
-
-One such component is Spring MVC, which takes advantage of the
-`DispatcherServlet` to redirect `HTTP` requests to the components that you have
-marked with the `@Controller` or `@RestController` annotations. A "servlet" in
-Java is a special class that can listen to incoming web connections, understand
-the corresponding `HTTP` protocol, read the request parameters and knows how to
-write a response back to the original caller.
-
-Just as the Spring Framework's AOP support allows the Spring Framework to proxy
-your service, Java supports "filters" for servlets. Servlet filters are the
-ability to implement an interceptor for incoming `HTTP` requests that will see
-every single request to your servlet before it actually reaches your servlet.
-This interceptor will have the ability to examine your request, perform logic
-and then decide whether to forward the original request to your servlet.
-
-Not only that, but Java can actually implement servlet filter "chains", which
-means that instead of handing the incoming request to your servlet after it's
-done with it, a filter can actually hand the incoming request to another filter.
-This is a key aspect of filters because it provides the foundation for being
-able to have dedicated filters for each type of "request filtering" we might
-want to implement. For example, we might want to:
-
-1. Examine an incoming request to validate authentication information (are you
-   who you claim to be)
-2. Examine an incoming request to validate authorization informatin (are you
-   allowed to perform the action you're trying to perform)
-
-As we will see in this section and the next, these two concerns are quite
-different and should not be handled by the same code.
-
-### Spring `DefaultSecurityFilterChain`
-
-Now that you have enabled Spring Security in your application, your startup log
-should have a line with information about the `DefaultSecurityFilterChain`,
-which will look something like this (the exact output may look slightly
-different based on the exact version of the Spring Framework you're running):
-
-```java
-2022-07-05 02:18:20.592  INFO 96327 --- [           main] o.s.s.web.DefaultSecurityFilterChain     : Will secure any request with [org.springframework.security.web.session.DisableEncodeUrlFilter@4b6e1c0, org.springframework.security.web.context.request.async.WebAsyncManagerIntegrationFilter@561b61ed, org.springframework.security.web.context.SecurityContextPersistenceFilter@1907874b, org.springframework.security.web.header.HeaderWriterFilter@1292071f, org.springframework.security.web.csrf.CsrfFilter@1aabf50d, org.springframework.security.web.authentication.logout.LogoutFilter@1b1f5012, org.springframework.security.web.savedrequest.RequestCacheAwareFilter@5b3a7ef5, org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter@5d21202d, org.springframework.security.web.authentication.AnonymousAuthenticationFilter@654c7d2d, org.springframework.security.web.session.SessionManagementFilter@5b9396d3, org.springframework.security.web.access.ExceptionTranslationFilter@1a4d1ab7, org.springframework.security.web.access.intercept.FilterSecurityInterceptor@5bc28f40]
-```
-
-This is one of those lines of text that's not very easy to read in a single
-line, so let's break it up into multiple lines:
-
-```java
-2022-07-05 02:18:20.592  INFO 96327 --- [           main] o.s.s.web.DefaultSecurityFilterChain     :
-        Will secure any request with
-        [org.springframework.security.web.session.DisableEncodeUrlFilter@4b6e1c0,
-        org.springframework.security.web.context.request.async.WebAsyncManagerIntegrationFilter@561b61ed,
-        org.springframework.security.web.context.SecurityContextPersistenceFilter@1907874b,
-        org.springframework.security.web.header.HeaderWriterFilter@1292071f,
-        org.springframework.security.web.csrf.CsrfFilter@1aabf50d,
-        org.springframework.security.web.authentication.logout.LogoutFilter@1b1f5012,
-        org.springframework.security.web.savedrequest.RequestCacheAwareFilter@5b3a7ef5,
-        org.springframework.security.web.servletapi.SecurityContextHolderAwareRequestFilter@5d21202d,
-        org.springframework.security.web.authentication.AnonymousAuthenticationFilter@654c7d2d,
-        org.springframework.security.web.session.SessionManagementFilter@5b9396d3,
-        org.springframework.security.web.access.ExceptionTranslationFilter@1a4d1ab7,
-        org.springframework.security.web.access.intercept.FilterSecurityInterceptor@5bc28f40]
-```
-
-What the Spring Framework is telling you is that because you have enabled Spring
-Security, it has now configured these default servlet filters and that they are
-all chained together, which means you can choose to take advantage of any
-combination of them.
-
-Let's look at some of the most commonly used filters in this chain:
-
-- BasicAuthenticationFilter: tells Spring Security to look for a
-  `Basic Auth HTTP` header on the request and extract the username and password
-  to authenticate the user.
-- UsernamePasswordAuthenticationFilter: tells Spring Security to look for the
-  username and password in the request parameter or `POST` body and use them to
-  authenticate the user.
-- DefaultLoginPageGeneratingFilter: tells Spring Security to generate a default
-  login page.
-- DefaultLogoutPageGeneratingFilter: tells Spring Security to generate a default
-  logout page.
-- FilterSecurityInterceptor: tells Spring Security to implement a default
-  Authorization mechanism
-
-Let's look at how to configure these filters.
+Let's explore that option more in this lesson.
 
 ## Spring Security Authentication
 
-Let's go ahead and add our `configure()` method to the `SecurityConfiguration`
-class again and give it a very basic implementation:
-
-```java
-package com.flatiron.spring.FlatironSpring;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-
-@Configuration
-@EnableWebSecurity
-public class SecurityConfiguration  extends WebSecurityConfigurerAdapter {
-
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-      http.authorizeRequests()
-              .anyRequest().permitAll();
-    }
-}
-```
-
-In this basic configuration, we are using the `HttpSecurity` object to call its
-`authorizeRequests()` method and tell it to `permitAll()` for any request that
-comes to our application.
-
-This current setup, of course, is not very useful, since we're simply allowing
-any incoming request to go through. We are going to come up with some
-incrementally more customized security options in the next few steps.
-
-First, let's explicitly force all requests be authenticated:
-
-```java
-package com.flatiron.spring.FlatironSpring;
-
-import org.springframework.context.annotation.Configuration;
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;
-import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
-
-@Configuration
-@EnableWebSecurity
-public class SecurityConfiguration  extends WebSecurityConfigurerAdapter {
-
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        http.authorizeRequests()
-                .anyRequest().authenticated()
-                .and()
-                .formLogin();
-    }
-}
-```
-
-Let's put the 2 versions of the call to `authorizeRequests()` side by side:
-
-- http.authorizeRequests().anyRequest().permitAll();
-- http.authorizeRequests().anyRequest().authenticated().and().formLogin();
-
-Let's examine the differences:
-
-- As you can see, we are applying our new rule to the same types of requests as
-  before by calling `anyRequest()`. Later in this section, we will look at how
-  to apply our rules to a subset of requests.
-- But now instead of asking any request to have the `permitAll()` method apply
-  to it, we are saying that any request actually needs to be `authenticated()`
-  in order to proceed
-- The `and()` after the call to `authenticated()` allows us to chain together
-  all the calls we need in order to configure our Spring Security, rather than
-  having to assign the returns from each method to a variable and then calling
-  additional methods on those variables
-- The next instruction we give to Spring Security is to enable `formLogin()` as
-  the authentication method.
-
-These changes get us back to where we are now challenged with Spring's default
-login page when we try to access our `hello` endpoint:
-
-![Spring Framework default simple authentication](https://curriculum-content.s3.amazonaws.com/java-spring-2/spring-testing-simple-auth.png)
-
-When Spring is configured with default security, the default user it sets up is
-`user` and the password is actually displayed on the console of your application
-when it starts up. You should see an ouput similar to this:
-
-```java
-2022-07-02 11:37:40.962  WARN 13313 --- [           main] .s.s.UserDetailsServiceAutoConfiguration :
-
-Using generated security password: b5de1159-3225-4224-9375-51098c6929a9
-
-This generated password is for development use only. Your security configuration must be updated before running your application in production.
-```
-
-Use those credentials on the login screen you see, and you should now be able to
-access your `hello` endpoint.
-
-Now that we've configured some default security and that we've been able to
-manually test that it works as expected, let's make sure that our automated
-tests are running properly. Let's run our entire test suite:
-
-![Failed Integration Tests](https://curriculum-content.s3.amazonaws.com/java-spring-2/spring-security-integration-tests-fail.png)
-
-There are a couple of interesting results that highlight the value of separating
-unit tests from integration and acceptance tests:
-
-1. All our unit tests continue to pass: this is expected as those tests are not
-   integrated with the Spring Framework and instead focus on the narrow
-   functionality of specific methods. These are correctly not impacted by the
-   general authentication concerns of the overall application.
-2. Our integration and acceptance tests fail: this is also expected, as we have
-   now changed how requests are allowed to get to our endpoint. Since both our
-   integration and acceptance tests do submit a request to our endpoint, they
-   now must also provide authentication credentials in order to be allowed to
-   proceed.
-
-Thankfully, the Spring Framework provides ways to handle authentication in our
-tests.
-
-First, we have to add a new dependency to our project to get access to some
-useful annotations for security testing:
-
-- If using Gradle, add the following dependency:
-
-```json
-  testImplementation 'org.springframework.security:spring-security-test'
-```
-
-- If using Maven, add the following dependency:
-
-```xml
-<dependency>
-    <groupId>org.springframework.security</groupId>
-    <artifactId>spring-security-test</artifactId>
-    <scope>test</scope>
-</dependency>
-```
-
-The easiest way to let our `mockMvc` object know that credentials should be
-provided with each request is to use the `@MockUser` annotation. This tells
-Spring to create a mock user object and pass its credentials information along
-with each request that is performed on the `mockMvc` object:
-
-```java
-package com.flatiron.spring.FlatironSpring;
-
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.web.servlet.MockMvc;
-
-import static org.hamcrest.Matchers.containsString;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-@SpringBootTest
-@AutoConfigureMockMvc
-class HelloControllerAcceptanceTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @WithMockUser
-    @Test
-    void shouldGreetDefault() throws Exception {
-        mockMvc.perform(get("/hello"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString("Hello Stephanie")));
-    }
-
-    @WithMockUser
-    @Test
-    void shouldGreetByName() throws Exception {
-        String greetingName = "Jamie";
-        mockMvc.perform(get("/hello")
-                        .param("targetName", greetingName))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString("Hello " + greetingName)));
-    }
-}
-```
-
-You should now be able to run the acceptance test and have it pass. Make the
-same changes to your integration test and it will also pass:
-
-```java
-package com.flatiron.spring.FlatironSpring;
-
-import org.junit.jupiter.api.Test;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.boot.test.mock.mockito.MockBean;
-import org.springframework.security.test.context.support.WithMockUser;
-import org.springframework.test.web.servlet.MockMvc;
-
-import static org.hamcrest.Matchers.containsString;
-import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
-
-@WebMvcTest(HelloController.class)
-class HelloControllerIntegrationTest {
-
-    @Autowired
-    private MockMvc mockMvc;
-    @MockBean
-    private JokeService jokeService;
-
-    @WithMockUser
-    @Test
-    void shouldGreetDefault() throws Exception {
-        mockMvc.perform(get("/hello"))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString("Hello Stephanie")));
-    }
-
-    @WithMockUser
-    @Test
-    void shouldGreetByName() throws Exception {
-        String greetingName = "Jamie";
-        mockMvc.perform(get("/hello")
-                .param("targetName", greetingName))
-                .andDo(print())
-                .andExpect(status().isOk())
-                .andExpect(content().string(containsString("Hello " + greetingName)));
-    }
-}
-```
-
-It's important to understand that the `@WithMockUser` annotation creates an
-authenticated user and adds it to the security context of `mockMvc`. In other
-words, the "mock user" doesn't actually go through the security chain to have
-its credentials validated - instead Spring injects an "authenticated" version of
-that user in the security context _as if_ the user had gotten authenticated.
-
-To drive that distinction home, we can actually give the `MockUser` a username
-of a user that doesn't exist and see that our integration test will still pass:
-
-```java
-    // ...
-
-    @WithMockUser(username = "fakeuser")
-    @Test
-    void shouldGreetDefault() throws Exception {
-
-    // ...
-```
-
-Now that we have all our tests running and passing, let's look at some ways to
-customize our default security configuration.
-
-## Adding our own users
-
-So far, we have only used the built-in default `user` user generated for us by
-the Spring Framework.
+Up until this point, we have used the built-in default `user` user generated for
+us by the Spring Framework.
 
 We can, however, get users from any source we want by creating a custom
 `UserDetailsService` that can either return users it creates itself, or use an
-external data source to fetch the users from a database or another service.
+external data source to fetch the users from a database or another service. We
+will first look at how to implement the former option.
 
-Let's add a new method to our `SecurityConfiguration` class:
+As we saw in the last lesson, all the endpoints are now protected under Spring
+Security by default. So what exactly is happening when we authenticate a user?
+When we send a request to the server, it can be intercepted by an authentication
+filter. The authentication filter will hand off the request to the
+authentication manager and authentication provider to check for a
+**user details service** and a **password encoder**. The `UserDetailsService`
+interface loads user-specific data, such as a username and password. The
+`PasswordEncoder` interface implements password management and is used in
+conjunction with the `UserDetailsService` when authenticating. Below is a
+diagram to illustrate the flow of Spring authentication.
+
+![spring-authentication-diagram](https://curriculum-content.s3.amazonaws.com/spring-mod-2/authentication/spring-authentication-diagram.png)
+
+We'll create our own `UserDetailsService` and `PasswordEncoder` beans to add our
+own user!
+
+Open up the `SecurityConfiguration` class we created in the
+`spring-security-demo` project we created in the last lesson. This is where we
+will customize our application's authentication. Go ahead and add the following
+code:
 
 ```java
+package com.example.springsecuritydemo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+
+@Configuration
+public class SecurityConfiguration {
+
     @Bean
     public UserDetailsService userDetailsService() {
-        InMemoryUserDetailsManager userDetailService = new InMemoryUserDetailsManager();
+        InMemoryUserDetailsManager userDetailsService = new InMemoryUserDetailsManager();
 
-        UserDetails user1 = User.withUsername("mary")
+        UserDetails user = User.withUsername("mary")
                 .password(passwordEncoder().encode("test"))
                 .authorities("read")
                 .build();
-        userDetailService.createUser(user1);
 
-        return userDetailService;
+        userDetailsService.createUser(user);
+
+        return userDetailsService;
     }
 
     @Bean
     PasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();
     }
-
+}
 ```
 
-Let's break it down:
+Let's break down this code:
 
-1. We create a user details service that can manage all the users we will add to
-   it "in memory" - this means these users will not be saved to file or in a
-   database anywhere, and will cease to exist when the application is stopped.
-   This would not work for a production-level application, but it is a good way
-   to demonstrate the mechanism of `UserDetailsService` without having to worry
-   about persistence or service integration.
-2. We create a test user using the `User` class
-3. We give that user a username and a password. Note that in Spring 5, we are
-   required to encode the password, so we use a standard encoder's `encode()`
-   method.
-4. Even though we have not covered authorization yet, we do have to give our
-   user a default "authority" - we will explain what that means in a later
-   section.
-5. We add our new user to the user details service and return the user details
-   service.
+- We will first create two bean methods: `userDetailsService()` and
+  `passwordEncoder()`.
+- The `userDetailsService()` method will return a `UserDetailsService` instance.
+  The `UserDetailsService` has a handful of implementing classes. We'll use the
+  `InMemoryUserDetailsManager` implementation to manage all the users we add to
+  it "in memory" - this means these users will not be saved to a file or in a
+  database anywhere, and will cease to exist when the application is stopped.
+  This would not work for a production-level application, but it is a good way
+  to demonstrate the mechanism of `UserDetailsService` without having to worry
+  about persistence or service integration.
+- Next we create a test user using the `User` class that is part of the
+  `org.springframework.security.core.userdetails` package. To create a user, we
+  need to provide that user a username and a password.
+  - Note that in Spring 5, we are required to encode the password. To do so, we
+    will have the `passwordEncoder()` method return a new `PasswordEncoder`
+    instance. `BCryptPasswordEncoder` is the recommended password encoder to
+    use, so we'll return an instance of that implementation.
+- Even though we have not yet covered authorization yet, we do have to give our
+  user a default "authority". We'll explain what that means in a later lesson.
+- Finally, we'll add our new `user` to the `userDetailsService` and then return
+  the `userDetailService`.
 
-When you restart your application, you will see that you now need to
-authenticate using the username/password combination that we defined in our
-custom `UserDetailsService`.
+Let's restart the application and see what happens.
 
-## Finer grain access control
+![intellij-console](https://curriculum-content.s3.amazonaws.com/spring-mod-2/authentication/intellij-spring-security-console.png)
+
+Notice when we start the application this time that we do not see the
+auto-generated password anymore. This means we now will have to pass in the
+username/password combination that we defined in our custom `UserDetailsService`
+bean.
+
+![basic-auth-credentials](https://curriculum-content.s3.amazonaws.com/spring-mod-2/authentication/postman-basic-auth-mary-test-credentials.png)
+
+If we send the request now with these credentials, we'll hit our `/hello`
+endpoint again!
+
+## User Authentication and PostgreSQL
+
+Now that we know how to authenticate using a user "in-memory", let's talk about
+updating our application to use a user stored in a database.
+
+For this, we'll need to add some dependencies to our project. Open up the
+`pom.xml` file to add the Spring Data JPA dependency and the PostgreSQL Driver
+dependency:
+
+```xml
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.springframework.boot</groupId>
+    <artifactId>spring-boot-starter-parent</artifactId>
+    <version>2.7.6</version>
+    <relativePath/> <!-- lookup parent from repository -->
+  </parent>
+  <groupId>com.example</groupId>
+  <artifactId>spring-security-demo</artifactId>
+  <version>0.0.1-SNAPSHOT</version>
+  <name>spring-security-demo</name>
+  <description>spring-security-demo</description>
+  <properties>
+    <java.version>11</java.version>
+  </properties>
+  <dependencies>
+    <!-- Add the Spring Data JPA dependency -->
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-jpa</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-client</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-oauth2-resource-server</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-security</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+    </dependency>
+    <!-- Add the PostgreSQL Driver dependency -->
+    <dependency>
+      <groupId>org.postgresql</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.security</groupId>
+      <artifactId>spring-security-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.springframework.boot</groupId>
+        <artifactId>spring-boot-maven-plugin</artifactId>
+        <version>${project.parent.version}</version>
+        <configuration>
+          <excludes>
+            <exclude>
+              <groupId>org.projectlombok</groupId>
+              <artifactId>lombok</artifactId>
+            </exclude>
+          </excludes>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>
+```
+
+Once the dependencies have been added to the `pom.xml`, click the little
+Maven icon in the upper-right hand corner of to reload the changes:
+
+![load-maven-changes](https://curriculum-content.s3.amazonaws.com/spring-mod-2/authentication/load-maven-changes.png)
+
+Now let's create our a database that we can connect to in order to access user
+data! Open up pgAdmin4 and create a new database. Let's call it "security_demo".
+
+![create-security-demo-db](https://curriculum-content.s3.amazonaws.com/spring-mod-2/authentication/create-sercurity-demo-db.png)
+
+Once the database has been created, open up the Query Tool and copy in the
+following to create the `users` table and a user with the same credentials we
+saw previously:
+
+```postgresql
+DROP TABLE IF EXISTS users;
+
+CREATE TABLE users (
+  id INTEGER PRIMARY KEY,
+  username TEXT NOT NULL,
+  password TEXT NOT NULL
+);
+
+INSERT INTO users(id, username, password) VALUES(1, 'mary', 'test');
+```
+
+Execute the query and then run a `SELECT * FROM users;` query to ensure the
+user, "mary", has been added to the database table.
+
+Now we'll need to add some packages and classes to our application. Go ahead and
+create a `repository`, `entity`, and `service` package with `UserRepository`,
+`User`, and `UserService` classes. The following should be the new project
+structure:
+
+```text
+├── HELP.md
+├── mvnw
+├── mvnw.cmd
+├── pom.xml
+└── src
+    ├── main
+    │   ├── java
+    │   │   └── com
+    │   │       └── example
+    │   │           └── springsecuritydemo
+    │   │               ├── SpringSecurityDemoApplication.java
+    │   │               ├── config
+    │   │               │   └── SecurityConfiguration.java
+    │   │               ├── controller
+    │   │               │   └── DemoController.java
+    │   │               ├── entity
+    │   │               │   └── User.java
+    │   │               ├── repository
+    │   │               │   └── UserRepository.java
+    │   │               └── service
+    │   │                   └── UserService.java
+    │   └── resources
+    │       ├── application.properties
+    │       ├── static
+    │       └── templates
+    └── test
+        └── java
+            └── org
+                └── example
+                    └── springsecuritydemo
+                        └── SpringSecurityDemoApplicationTests.java
+```
+
+In the `User` class, add the following code to match the `users` table we just
+created:
+
+```java
+package com.example.springsecuritydemo.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue
+    private int id;
+
+    private String username;
+
+    private String password;
+}
+```
+
+Let's add the code for the `UserRepository` class as well:
+
+```java
+package com.example.springsecuritydemo.repository;
+
+// Make sure you import the correct User class
+import com.example.springsecuritydemo.entity.User;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends CrudRepository<User, Integer> {
+
+    Optional<User> findUserByUsername(String username);
+}
+```
+
+We'll also add the following to the `application.properties` file so we can
+connect to our `security_demo` database:
+
+```properties
+spring.datasource.url= jdbc:postgresql://localhost:5432/security_demo
+spring.datasource.username= postgres
+spring.datasource.password=postgres
+spring.datasource.driver-class-name=org.postgresql.Driver
+
+# Hibernate ddl auto (create, create-drop, validate, update)
+spring.jpa.hibernate.ddl-auto=update
+spring.jpa.properties.hibernate.dialect= org.hibernate.dialect.PostgreSQLDialect
+spring.jpa.properties.hibernate.globally_quoted_identifiers=true
+```
+
+Now for the `UserService` class, we want to implement the `UserDetailsService`
+that we used in the last example. This will allow our service to become an
+implementation of the `UserDetailsService` that the Authentication Provider will
+call upon to check the user details.
+
+```java
+package com.example.springsecuritydemo.service;
+
+import com.example.springsecuritydemo.entity.User;
+import com.example.springsecuritydemo.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class UserService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Autowired
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Optional<User> user = userRepository.findUserByUsername(username);
+
+        // How do we turn our Optional<User> into UserDetails?
+    }
+}
+```
+
+Let's look at the code above.
+
+We'll have the `UserService` implement the `UserDetailsService`, which means we
+will need to override the `loadUserByUsername()` method. In the method, we'll
+call the `findUserByUsername()` method we created in our repository class. This
+will return an `Optional<User>`.
+
+But uh-oh. We aren't supposed to return an `Optional<User>` or even just the
+`User` entity. We need to return a `UserDetails` instance. So how do we do that?
+
+Let's create a wrapper class that encompasses a `User` instance and implements
+the `UserDetails` interface. Within the `entity` package, create a
+`UserWrapper.java` file that implements the `UserDetails` interface. We'll also
+have to override several methods. Consider the following implementation:
+
+```java
+package com.example.springsecuritydemo.entity;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Collection;
+import java.util.List;
+
+public class UserWrapper implements UserDetails {
+
+  private final User user;
+
+  public UserWrapper(User user) {
+    this.user = user;
+  }
+
+  @Override
+  public String getUsername() {
+    return user.getUsername();
+  }
+
+  @Override
+  public String getPassword() {
+    // We'll need to encode the user's password before we return it
+    return new BCryptPasswordEncoder().encode(user.getPassword());
+  }
+
+  @Override
+  public Collection<? extends GrantedAuthority> getAuthorities() {
+    return List.of(() -> "read");
+  }
+
+  @Override
+  public boolean isAccountNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isAccountNonLocked() {
+    return true;
+  }
+
+  @Override
+  public boolean isCredentialsNonExpired() {
+    return true;
+  }
+
+  @Override
+  public boolean isEnabled() {
+    return true;
+  }
+}
+```
+
+Let's break down this code a little bit more:
+
+- Create a private final `User` instance that will be passed into a
+  `UserWrapper` constructor.
+- Override the `getUsername()` method by returning the user's username:
+  `return user.getUsername();`
+- Override the `getPassword()` method by returning the encoded user's password:
+  `return new BCryptPasswordEncoder().encode(user.getPassword());`
+- Override the `getAuthorities()` method by returning a list with an authority
+  of "read". We'll elaborate more on this in the next lesson.
+- Have the `isAccountNonExpired()`, `isAccountNonLocked()`,
+  `isCredentialsNonExpired()`, and `isEnabled()` methods all return true.
+  - These methods have to do with looking to see if the user is locked out,
+    expired, and enabled. For our purposes, we'll be leaving these set to true
+    so we won't have to worry about expired or locked credentials.
+
+We'll return now to the `UserService` class and finish overriding the
+`loadUserByUsername()` method:
+
+```java
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Optional<User> user = userRepository.findUserByUsername(username);
+
+        return user.map(UserWrapper::new).orElseThrow(() -> new UsernameNotFoundException("Username not found"));
+    }
+```
+
+We're almost ready to run our application! Let's go back into our
+`SecurityConfiguration` class and remove the `userDetailsService()` bean
+method:
+
+```java
+package com.example.springsecuritydemo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+@Configuration
+public class SecurityConfiguration {
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}
+```
+
+Now run the application! We should be able to enter the same credentials as
+before and have it still work - except this time we're making use of our
+database!
+
+![basic-auth-credentials](https://curriculum-content.s3.amazonaws.com/spring-mod-2/authentication/postman-basic-auth-mary-test-credentials.png)
+
+## Specifying Authentication on Certain Endpoints
 
 Let's consider that we may not want all our endpoints to require a user to be
 authenticated. With our current configuration any endpoint that we create will
 require the user to be authenticated. Let's validate this by adding a new
-endpoint in our `HelloController` class:
+endpoint in our `DemoController` class:
 
 ```java
     @GetMapping("/status")
@@ -428,80 +525,335 @@ endpoint in our `HelloController` class:
     }
 ```
 
-As you can imagine, the status of our application shouldn't be something that
+As we can imagine, the status of our application shouldn't be something that
 all users can access. Sure enough, based on our current configuration, this
 endpoint will be protected just like our `/hello` endpoint. Go ahead and restart
-your application to validate this.
+the application to validate this.
 
 Our issue now is that we don't actually want the `/hello` endpoint to be
 protected anymore. That's something we did for testing, but in reality we
 actually want any user who interfaces with our API to be able to get our basic
 greeting message.
 
-We can do this be modifying our `configure()` method in our
+To specify that we want the `/hello` endpoint to be public, or not
+authenticated, and the `/status` endpoint to be protected, we can create a new
+bean method to return a `SecurityFilterChain`. Add the following method to the
 `SecurityConfiguration` class:
 
 ```java
-    @Override
-    protected void configure(HttpSecurity http) throws Exception {
-        http.authorizeRequests()
-                .antMatchers("/hello")
-                .permitAll();
-
-        http.authorizeRequests()
-                .anyRequest()
-                .authenticated()
-                .and()
-                .formLogin();
-
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity.httpBasic().and().authorizeRequests().antMatchers("/hello").permitAll();
+        httpSecurity.httpBasic().and().authorizeRequests().anyRequest().authenticated();
+        return httpSecurity.build();
     }
 ```
 
-We have now added a new entry for a specific URL (`/hello`), using the
-`antMatchers()` method, which works this way:
+So what is this code doing?
 
-1. `antMatchers()` can match:
-   1. A specific URL path
-   2. A specific `HTTP` method (`GET`, `POST`, etc...)
-   3. A specific URL path and a specific `HTTP` method
-   4. A path pattern in place of a specific path, wherever a specific path could
-      be used in the previous points. The following are the rules for the
-      patterns:
-      1. A "?" matches a single character
-      2. A single "\*" matches 0 or more characters
-      3. A double "\*", i.e. "\*\*", matches 0 or more paths
+- We first specify that if the request coming through matches the endpoint
+  `/hello` to always permit it without having to be authenticated. We accomplish
+  this in the line:
+  `httpSecurity.httpBasic().and().authorizeRequests().antMatchers("/hello").permitAll();`
+- Next, we force all other requests coming through to be authenticated with the
+  line:
+  `httpSecurity.httpBasic().and().authorizeRequests().anyRequest().authenticated();`
+- Notice the difference between these two lines of code. The `permitAll()`
+  method will allow requests to pass through while the `authenticated()` method
+  forces the request to be authenticated.
+- The `anyRequest()` method is generic to say we want all requests whereas the
+  `antMatchers()` method takes in a specific pattern that the request must
+  match. `antMatchers()` can match:
+  - A specific URL path.
+  - A specific HTTP method (GET, POST, etc.).
+  - A specific URL path and a specific HTTP method.
+  - A path pattern in place of a specific path, wherever a specific path could
+    be used in the previous points. The following are the rules for the
+    patterns:
+    - A "?" matches a single character.
+    - A single "\*" matches 0 or more characters.
+    - A double "\**", i.e. "\*\*", matches 0 or more paths.
+- `antMatchers` can be chained and should be ordered from most specific to least
+  specific, which is why in our example, the `/hello` URL is open while all
+  other URLs are protected and require authentication. Even though the `/hello`
+  URL does match the more general pattern, since there is another rule that is
+  more specific and precedes the general rule, it is matched first.
 
-`antMatchers` can be chained and should be ordered from most specific to least
-specific, which is why in our example the `/hello` URL is open while all other
-URLs are behind the authentication form. Even though the `/hello` URL does match
-the more general pattern, since there is another rule that is more specific and
-precedes the more general rule, it is matched first and the `/hello` URL is
-open.
+Let's test this out! Restart the application and open up Postman.
 
-## Logout
+We'll first test out the case when the user is _not_ authenticated. We should be
+able to hit the `/hello` endpoint but not the `/status` endpoint. To remove the
+authentication, navigate to the "Authorization" tab in Postman and next to
+"Type" select "No Auth" from the dropdown menu.
 
-In the same way that Spring Framework can provide us with a standard login form,
-it can also provide us with a standard logout form that logs the user out of the
-system. This is handy for us to have as we continue to test different scenarios
-and add more than one user.
+In the request URL, let's send a GET request:
+"http://localhost:8080/hello?name=mary". Click "Send" to send the request. We
+should see that without any authentication, we can reach the endpoint and get
+back a message saying "Hello mary".
 
-We need to request a logout form in much the same way we requested a login form,
-which we can do by adding to the `formLogin()` chain we already have:
+![postmnan-no-auth](https://curriculum-content.s3.amazonaws.com/spring-mod-2/authentication/postman-no-authentication.png)
 
-```java
-        http.authorizeRequests()
-                .anyRequest()
-                .authenticated()
-                .and()
-                .formLogin()
-                .and() // add to the chain
-                .logout(); // request a logout form
+Now let's change the GET request URL to "http://localhost:8080/status" to see if
+the `/status` endpoint is being blocked since we aren't authenticated:
+
+![postman-401-unauthorized](https://curriculum-content.s3.amazonaws.com/spring-mod-2/authentication/postman-unauthorized.png)
+
+It looks like it worked!
+
+Let's add our basic authentication back in the "Authorization" tab and ensure
+we can hit the status endpoint again.
+
+![postman-authenticated](https://curriculum-content.s3.amazonaws.com/spring-mod-2/authentication/postman-authenticated-status.png)
+
+## Code Check
+
+Check the project structure and code in each class to ensure your code matches
+what was covered in this lesson.
+
+### Project Structure
+
+```text
+├── HELP.md
+├── mvnw
+├── mvnw.cmd
+├── pom.xml
+└── src
+    ├── main
+    │   ├── java
+    │   │   └── com
+    │   │       └── example
+    │   │           └── springsecuritydemo
+    │   │               ├── SpringSecurityDemoApplication.java
+    │   │               ├── config
+    │   │               │   └── SecurityConfiguration.java
+    │   │               ├── controller
+    │   │               │   └── DemoController.java
+    │   │               ├── entity
+    │   │               │   ├── User.java
+    │   │               │   └── UserWrapper.java
+    │   │               ├── repository
+    │   │               │   └── UserRepository.java
+    │   │               └── service
+    │   │                   └── UserService.java
+    │   └── resources
+    │       ├── application.properties
+    │       ├── static
+    │       └── templates
+    └── test
+        └── java
+            └── org
+                └── example
+                    └── springsecuritydemo
+                        └── SpringSecurityDemoApplicationTests.java
 ```
 
-You can now go to your logout form by going to the `/logout` URL on your
-`localhost`.
+### SecurityConfiguration.java
+
+```java
+package com.example.springsecuritydemo.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfiguration {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity httpSecurity) throws Exception {
+        httpSecurity.httpBasic().and().authorizeRequests().antMatchers("/hello").permitAll();
+        httpSecurity.httpBasic().and().authorizeRequests().anyRequest().authenticated();
+        return httpSecurity.build();
+    }
+
+    @Bean
+    PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}
+```
+
+### DemoController.java
+
+```java
+package com.example.springsecuritydemo.controller;
+
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+public class DemoController {
+
+    @GetMapping("/hello")
+    public String hello(@RequestParam(defaultValue = "person") String name) {
+        return String.format("Hello %s", name);
+    }
+
+    @GetMapping("/status")
+    public String status() {
+        return "Congratulations - you must be an admin since you can see the application's status information";
+    }
+}
+```
+
+### Users.java
+
+```java
+package com.example.springsecuritydemo.entity;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.Id;
+import javax.persistence.Table;
+
+@Entity
+@Getter
+@Setter
+@NoArgsConstructor
+@Table(name = "users")
+public class User {
+
+    @Id
+    @GeneratedValue
+    private int id;
+
+    private String username;
+
+    private String password;
+}
+```
+
+### UserWrapper.java
+
+```java
+package com.example.springsecuritydemo.entity;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Collection;
+import java.util.List;
+
+public class UserWrapper implements UserDetails {
+
+    private final User user;
+
+    public UserWrapper(User user) {
+        this.user = user;
+    }
+
+    @Override
+    public String getUsername() {
+        return user.getUsername();
+    }
+
+    @Override
+    public String getPassword() {
+        // We'll need to encode the user's password before we return it
+        return new BCryptPasswordEncoder().encode(user.getPassword());
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of(() -> "read");
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}
+```
+
+### UserRepository.java
+
+```java
+package com.example.springsecuritydemo.repository;
+
+// Make sure you import the correct User class
+import com.example.springsecuritydemo.entity.User;
+import org.springframework.data.repository.CrudRepository;
+
+import java.util.Optional;
+
+public interface UserRepository extends CrudRepository<User, Integer> {
+
+    Optional<User> findUserByUsername(String username);
+}
+```
+
+### UserService.java
+
+```java
+package com.example.springsecuritydemo.service;
+
+import com.example.springsecuritydemo.entity.User;
+import com.example.springsecuritydemo.entity.UserWrapper;
+import com.example.springsecuritydemo.repository.UserRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Service
+public class UserService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Autowired
+    public UserService(UserRepository userRepository) {
+        this.userRepository = userRepository;
+    }
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        Optional<User> user = userRepository.findUserByUsername(username);
+
+        return user.map(UserWrapper::new).orElseThrow(() -> new UsernameNotFoundException("Username not found"));
+    }
+}
+```
 
 ## Conclusion
 
 We have learned how to set up authentication in this lesson. In the next one, we
 will go over authorization.
+
+## References
+
+- [Spring Security in Action](https://learning.oreilly.com/library/view/spring-security-in/9781617297731/OEBPS/Text/02.htm#heading_id_7)
+- [UserDetailsService Documentation](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/core/userdetails/UserDetailsService.html)
+- [InMemoryUserDetailsManager Documentation](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/provisioning/InMemoryUserDetailsManager.html)
+- [PasswordEncoder Documentation](https://docs.spring.io/spring-security/reference/servlet/authentication/passwords/password-encoder.html)
+- [Spring Security Fundamentals - Lesson 2 - Managing Users](https://youtu.be/dFvbHZ8CuKM)
+- [Spring Security: Authentication with a Database-backed UserDetailsService](https://www.baeldung.com/spring-security-authentication-with-a-database)
+- [Spring Security without the WebSecurityConfigurerAdapter](https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter)
+- [HttpSecurity Documentation](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/config/annotation/web/builders/HttpSecurity.html)
+- [Spring Security - security none, filters none, access permitAll](https://www.baeldung.com/security-none-filters-none-access-permitAll)

--- a/README.md
+++ b/README.md
@@ -440,7 +440,7 @@ Let's break down this code a little bit more:
 - Override the `getUsername()` method by returning the user's username:
   `return user.getUsername();`
 - Override the `getPassword()` method by returning the user's password:
-  `return `
+  `return user.getPassword();`
 - Override the `getAuthorities()` method by returning a list with an authority
   of "read". We'll elaborate more on this in the next lesson.
 - Have the `isAccountNonExpired()`, `isAccountNonLocked()`,

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ We'll create our own `UserDetailsService` and `PasswordEncoder` beans to add our
 own user!
 
 Open up the `SecurityConfiguration` class we created in the
-`spring-security-demo` project we created in the last lesson. This is where we
+`spring-security-demo` project that we used in the last lesson. This is where we
 will customize our application's authentication. Go ahead and add the following
 code:
 
@@ -216,7 +216,7 @@ dependency:
 ```
 
 Once the dependencies have been added to the `pom.xml`, click the little
-Maven icon in the upper-right hand corner of to reload the changes:
+Maven icon in the upper-right hand corner to reload the changes:
 
 ![load-maven-changes](https://curriculum-content.s3.amazonaws.com/spring-mod-2/authentication/load-maven-changes.png)
 
@@ -332,7 +332,7 @@ public interface UserRepository extends CrudRepository<User, Integer> {
 }
 ```
 
-We'll also add the following to the `application.properties` file so we can
+We'll also add the following to the `application.properties` file, so we can
 connect to our `security_demo` database:
 
 ```properties


### PR DESCRIPTION
This change is being made in the consumer canvas per the conversation on 7/22 to keep the same modules for Blackrock and AWS to streamline.

- Briefly explain how authentication works in Spring Security. 
- Remove servlet filter section, per Alvee, it is not important to go that in-depth and a general overview should suffice. This section has been saved off in a document, so please let me know if you think it should be included as an optional lesson. 
- Jump right into using adding users to authenticate. 
- Add section on authenticating a user from a PostgreSQL database.
- Show how to authenticate certain endpoints but have others fully exposed in the security configuration.
  - This had to be refactored as the `WebSecurityConfigurerAdapter` has been deprecated. See [Spring Security Without the WebSecurityConfigurerAdapter](https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter) blog post.
- Removed section on mocking up tests and unit testing as that will be covered in the next section.

This is honestly my first real exposure to Spring Security as my last job didn't take full advantage of these features and created their own security-type classes. Let me know how I did, if I missed anything, if I put the "UserWrapper" in the wrong package, etc.
